### PR TITLE
[ISSUE-15] Add address tag page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Progress from "./views/html-tags/Progress";
 import DynamicFavicon from "./views/DynamicFavicon";
 import Anchor from "./views/html-tags/Anchor";
 import Abbr from "./views/html-tags/Abbr";
+import Address from "./views/html-tags/Address";
 
 function NotFound() {
   return <h1>Not Found</h1>;
@@ -21,6 +22,7 @@ function App() {
             <Route path="/html-tags/progress" element={<Progress />} />
             <Route path="/html-tags/anchor" element={<Anchor />} />
             <Route path="/html-tags/abbr" element={<Abbr />} />
+            <Route path="/html-tags/address" element={<Address />} />
           </Route>
           <Route path="/js-scripts" element={<JsScriptsIndex />}>
             <Route

--- a/src/views/html-tags/Address.jsx
+++ b/src/views/html-tags/Address.jsx
@@ -1,0 +1,20 @@
+import { Container, Card } from "../../components";
+
+function Address() {
+  return (
+    <Container title="Address Tag">
+      <Card>
+        <div className="flex flex-col gap-1">
+          <h6>Basic Address</h6>
+          <address className="flex flex-col gap-2 w-60">
+            <a href="mailto:jim@example.com">jim@example.com</a>
+            <a href="tel:+14155550132">+1 (415) 555‑0132</a>
+          </address>
+          <p>Address can be</p>
+        </div>
+      </Card>
+    </Container>
+  );
+}
+
+export default Address;

--- a/src/views/html-tags/Index.jsx
+++ b/src/views/html-tags/Index.jsx
@@ -16,6 +16,9 @@ function Index() {
             <Link to="/html-tags/abbr">{"<abbr> Tag"}</Link>
           </li>
           <li>
+            <Link to="/html-tags/address">{"<address> Tag"}</Link>
+          </li>
+          <li>
             <Link to="/html-tags/progress">{"<progress> Tag"}</Link>
           </li>
         </ul>


### PR DESCRIPTION
`closes #15 `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new route for the Address component, allowing navigation to `/html-tags/address`.
	- Added a new Address component that displays structured address information with clickable email and phone links.
	- Enhanced navigation in the Index component with a new link to the Address documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->