### PR TITLE
[ISSUE-50] add: Code tag page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import Button from "./views/html-tags/Button";
 import Canvas from "./views/html-tags/Canvas";
 import Caption from "./views/html-tags/Caption";
 import Cite from "./views/html-tags/Cite";
+import Code from "./views/html-tags/Code";
 import Progress from "./views/html-tags/Progress";
 import ImageMap from "./views/responsive-design/ImageMap";
 
@@ -54,6 +55,7 @@ function App() {
             <Route path="/html-tags/canvas" element={<Canvas />} />
             <Route path="/html-tags/caption" element={<Caption />} />
             <Route path="/html-tags/cite" element={<Cite />} />
+            <Route path="/html-tags/code" element={<Code />} />
             <Route path="/html-tags/progress" element={<Progress />} />
           </Route>
           <Route path="/js-scripts" element={<JsScriptsIndex />}>

--- a/src/views/html-tags/Code.jsx
+++ b/src/views/html-tags/Code.jsx
@@ -1,0 +1,45 @@
+import { Container, Card } from "../../components";
+import classNames from "classnames";
+import PropTypes from "prop-types";
+
+const code = `<code>`;
+
+const message =
+  "is used to define a piece of computer code. By default, it is displayed in the browser's default monospace font.";
+
+function CodeTag({ isCustomStyle }) {
+  return (
+    <code
+      className={
+        isCustomStyle ? classNames("bg-gray-200 text-gray-800 p-1 rounded") : ""
+      }
+    >
+      {code}
+    </code>
+  );
+}
+
+CodeTag.propTypes = {
+  isCustomStyle: PropTypes.bool,
+};
+
+function CodePage() {
+  return (
+    <Container title={"<code> Tag"} full>
+      <Card>
+        <h2 className="text-xl">Basic Code tag</h2>
+        <p>
+          <CodeTag>{code}</CodeTag> <span>{message}</span>
+        </p>
+      </Card>
+      <Card>
+        <h2 className="text-xl">Custom Styles</h2>
+        <p>
+          <CodeTag isCustomStyle>{code}</CodeTag> <span>{message}</span>
+        </p>
+      </Card>
+    </Container>
+  );
+}
+
+export default CodePage;

--- a/src/views/html-tags/Index.jsx
+++ b/src/views/html-tags/Index.jsx
@@ -64,6 +64,9 @@ function Index() {
             <Link to="/html-tags/cite">{"<cite> Tag"}</Link>
           </li>
           <li>
+            <Link to="/html-tags/code">{"<code> Tag"}</Link>
+          </li>
+          <li>
             <Link to="/html-tags/progress">{"<progress> Tag"}</Link>
           </li>
         </ul>


### PR DESCRIPTION
`closes #50 `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new route for the HTML `<code>` tag documentation, accessible at `/html-tags/code`.
	- Added a `Code` component that displays information and examples for the `<code>` tag.
	- Enhanced the `Index` component with a link to the new `<code>` tag documentation.

- **Bug Fixes**
	- None

- **Documentation**
	- Updated the navigation structure to include the new `<code>` tag documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->