### PR TITLE
[ISSUE-52] Add Col tag page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import Canvas from "./views/html-tags/Canvas";
 import Caption from "./views/html-tags/Caption";
 import Cite from "./views/html-tags/Cite";
 import Code from "./views/html-tags/Code";
+import Col from "./views/html-tags/Col";
 import Progress from "./views/html-tags/Progress";
 import ImageMap from "./views/responsive-design/ImageMap";
 
@@ -56,6 +57,7 @@ function App() {
             <Route path="/html-tags/caption" element={<Caption />} />
             <Route path="/html-tags/cite" element={<Cite />} />
             <Route path="/html-tags/code" element={<Code />} />
+            <Route path="/html-tags/col" element={<Col />} />
             <Route path="/html-tags/progress" element={<Progress />} />
           </Route>
           <Route path="/js-scripts" element={<JsScriptsIndex />}>

--- a/src/views/html-tags/Col.jsx
+++ b/src/views/html-tags/Col.jsx
@@ -1,0 +1,88 @@
+import { Container, Card } from "../../components";
+import PropTypes from "prop-types";
+import { faker } from "@faker-js/faker";
+
+function TD({ children }) {
+  return (
+    <td className="px-6 py-4 border border-solid border-gray-500">
+      {children}
+    </td>
+  );
+}
+TD.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+function TH({ children }) {
+  return (
+    <th className="px-6 py-3 text-center border border-solid border-gray-500">
+      {children}
+    </th>
+  );
+}
+TH.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+function ColPage() {
+  function generateTableHeader() {
+    return faker.word.noun();
+  }
+  function generateCaption() {
+    return faker.lorem.sentence(2);
+  }
+  return (
+    <Container title={"<col> Tag"} full>
+      <Card>
+        <h2 className="text-xl">Single Col Span</h2>
+        <table className="border-collapse border border-solid">
+          <caption className="caption-bottom p-2">{generateCaption()}</caption>
+          <colgroup>
+            <col className="bg-gray-400" />
+            <col className="bg-red-300" />
+            <col className="bg-blue-400" />
+            <col className="bg-green-300" />
+            <col className="bg-yellow-300" />
+          </colgroup>
+          <tr>
+            <td></td>
+            {Array.from({ length: 4 }, (_, i) => (
+              <TH key={i}>{generateTableHeader()}</TH>
+            ))}
+          </tr>
+          <tr>
+            <th scope="row">Skill</th>
+            {Array.from({ length: 4 }, (_, i) => (
+              <TD key={i}>{generateTableHeader()}</TD>
+            ))}
+          </tr>
+        </table>
+      </Card>
+      <Card>
+        <h2 className="text-xl">Multiple Col Span</h2>
+        <table className="border-collapse border border-solid">
+          <caption className="caption-bottom p-2">{generateCaption()}</caption>
+          <colgroup>
+            <col className="bg-gray-400" />
+            <col className="bg-red-300" span={2} />
+            <col className="bg-blue-400" span={3} />
+          </colgroup>
+          <tr>
+            <td></td>
+            {Array.from({ length: 5 }, (_, i) => (
+              <TH key={i}>{generateTableHeader()}</TH>
+            ))}
+          </tr>
+          <tr>
+            <th scope="row">Skill</th>
+            {Array.from({ length: 5 }, (_, i) => (
+              <TD key={i}>{generateTableHeader()}</TD>
+            ))}
+          </tr>
+        </table>
+      </Card>
+    </Container>
+  );
+}
+
+export default ColPage;

--- a/src/views/html-tags/Index.jsx
+++ b/src/views/html-tags/Index.jsx
@@ -67,6 +67,9 @@ function Index() {
             <Link to="/html-tags/code">{"<code> Tag"}</Link>
           </li>
           <li>
+            <Link to="/html-tags/col">{"<col> Tag"}</Link>
+          </li>
+          <li>
             <Link to="/html-tags/progress">{"<progress> Tag"}</Link>
           </li>
         </ul>


### PR DESCRIPTION
`closes #52 `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new route for the `<col>` HTML tag, accessible at `/html-tags/col`.
	- Added a new `ColPage` component showcasing tables that demonstrate the use of the `<col>` tag.
	- Updated the HTML tags index to include a link to the new `<col>` tag page.

- **Bug Fixes**
	- No bug fixes were included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->