### PR TITLE
[ISSUE-54] Add `<Colgroup>` page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ import Caption from "./views/html-tags/Caption";
 import Cite from "./views/html-tags/Cite";
 import Code from "./views/html-tags/Code";
 import Col from "./views/html-tags/Col";
+import Colgroup from "./views/html-tags/Colgroup";
 import Progress from "./views/html-tags/Progress";
 import ImageMap from "./views/responsive-design/ImageMap";
 
@@ -58,6 +59,7 @@ function App() {
             <Route path="/html-tags/cite" element={<Cite />} />
             <Route path="/html-tags/code" element={<Code />} />
             <Route path="/html-tags/col" element={<Col />} />
+            <Route path="/html-tags/colgroup" element={<Colgroup />} />
             <Route path="/html-tags/progress" element={<Progress />} />
           </Route>
           <Route path="/js-scripts" element={<JsScriptsIndex />}>

--- a/src/views/html-tags/Colgroup.jsx
+++ b/src/views/html-tags/Colgroup.jsx
@@ -1,0 +1,65 @@
+import { Container, Card } from "../../components";
+import PropTypes from "prop-types";
+import { faker } from "@faker-js/faker";
+
+function TD({ children }) {
+  return (
+    <td className="px-3 py-4 border border-solid border-gray-500">
+      {children}
+    </td>
+  );
+}
+TD.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+function TH({ children }) {
+  return (
+    <th className="px-6 py-3 text-center border border-solid border-gray-500">
+      {children}
+    </th>
+  );
+}
+TH.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+function ColGroupPage() {
+  function generateTableHeader() {
+    return faker.word.noun();
+  }
+  function generateCaption() {
+    return faker.lorem.sentence(2);
+  }
+  return (
+    <Container title={"<colgroup> Tag"} full>
+      <Card>
+        <h2 className="text-xl">Single Col Span</h2>
+        <table className="border-collapse border border-solid">
+          <caption className="caption-bottom p-2">{generateCaption()}</caption>
+          <col className="bg-gray-400" />
+          <colgroup span="4" className="bg-blue-100">
+            <col className="bg-red-300" />
+            <col />
+            <col />
+            <col />
+          </colgroup>
+          <tr>
+            <td></td>
+            {Array.from({ length: 4 }, (_, i) => (
+              <TH key={i}>{generateTableHeader()}</TH>
+            ))}
+          </tr>
+          <tr>
+            <th scope="row">Skill</th>
+            {Array.from({ length: 4 }, (_, i) => (
+              <TD key={i}>{generateTableHeader()}</TD>
+            ))}
+          </tr>
+        </table>
+      </Card>
+    </Container>
+  );
+}
+
+export default ColGroupPage;

--- a/src/views/html-tags/Index.jsx
+++ b/src/views/html-tags/Index.jsx
@@ -70,6 +70,9 @@ function Index() {
             <Link to="/html-tags/col">{"<col> Tag"}</Link>
           </li>
           <li>
+            <Link to="/html-tags/colgroup">{"<colgroup> Tag"}</Link>
+          </li>
+          <li>
             <Link to="/html-tags/progress">{"<progress> Tag"}</Link>
           </li>
         </ul>


### PR DESCRIPTION
`closes #54 `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new route for the `Colgroup` component, accessible at `/html-tags/colgroup`.
	- Added a new `ColGroupPage` component that renders a styled table using the `<colgroup>` HTML tag.
	- Updated the HTML tags index to include a link to the new `Colgroup` route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->