### PR TITLE
[ISSUE-66] Add dfn tag page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ import Datalist from "./views/html-tags/Datalist";
 import DescriptionDetails from "./views/html-tags/Description";
 import Delete from "./views/html-tags/Delete";
 import Details from "./views/html-tags/Details";
+import Definition from "./views/html-tags/Definition";
 import Progress from "./views/html-tags/Progress";
 import ImageMap from "./views/responsive-design/ImageMap";
 
@@ -73,6 +74,7 @@ function App() {
             />
             <Route path="/html-tags/delete" element={<Delete />} />
             <Route path="/html-tags/details" element={<Details />} />
+            <Route path="/html-tags/definition" element={<Definition />} />
             <Route path="/html-tags/progress" element={<Progress />} />
           </Route>
           <Route path="/js-scripts" element={<JsScriptsIndex />}>

--- a/src/views/html-tags/Definition.jsx
+++ b/src/views/html-tags/Definition.jsx
@@ -1,0 +1,71 @@
+import { Link } from "react-router-dom";
+import { Container, Card } from "../../components";
+
+function DefinitionPage() {
+  return (
+    <Container title={"<dfn> Tag"} full>
+      <Card>
+        <h2 className="text-xl">Definition</h2>
+        <p>
+          The{" "}
+          <strong>
+            HTML Definition element <dfn>&lt;dfn&gt;</dfn>
+          </strong>{" "}
+          is used to indicate the term being defined within the context of a
+          definition phrase or sentence.
+        </p>
+      </Card>
+      <Card>
+        <h2 className="text-xl">Link to definition</h2>
+        <p>
+          The
+          <strong>
+            HTML Definition element (<dfn id="definition-dfn">&lt;dfn&gt;</dfn>)
+          </strong>
+          is used to indicate the term being defined within the context of a
+          definition phrase or sentence.
+        </p>
+
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Graece donan,
+          Latine voluptatem vocant. Confecta res esset. Duo Reges: constructio
+          interrete. Scrupulum, inquam, abeunti;
+        </p>
+
+        <p>
+          Because of all of that, we decided to use the
+          <code>
+            <a href="#definition-dfn">&lt;dfn&gt;</a>
+          </code>{" "}
+          element for this project.
+        </p>
+      </Card>
+      <Card>
+        <h2 className="text-xl">
+          Definition with <code>title</code> attribute
+        </h2>
+        <p>
+          The
+          <strong>
+            HTML Definition element (
+            <dfn title="Definition Element">&lt;dfn&gt;</dfn>)
+          </strong>
+          is used to indicate the term being defined within the context of a
+          definition phrase or sentence.
+        </p>
+      </Card>
+      <Card>
+        <h2 className="text-xl">
+          Definition with <code>abbr</code> tag
+        </h2>
+        <p>
+          When dfn does not have a title attribute, and abbr is the only child,
+          the dfn element represents the term being defined. see{" "}
+          <Link to="/html-tags/abbr">{"<abbr> Tag"}</Link>
+        </p>
+      </Card>
+    </Container>
+  );
+}
+
+export default DefinitionPage;

--- a/src/views/html-tags/Index.jsx
+++ b/src/views/html-tags/Index.jsx
@@ -94,6 +94,9 @@ function Index() {
             <Link to="/html-tags/details">{"<details> Tag"}</Link>
           </li>
           <li>
+            <Link to="/html-tags/definition">{"<dfn> Tag"}</Link>
+          </li>
+          <li>
             <Link to="/html-tags/progress">{"<progress> Tag"}</Link>
           </li>
         </ul>


### PR DESCRIPTION
`closes #66 `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new route for the `Definition` component under `/html-tags/definition`.
	- Added a `DefinitionPage` component that provides detailed information about the HTML `<dfn>` tag.
	- Updated the `Index` component to include a link to the new `<dfn>` tag page.

- **Bug Fixes**
	- Minor formatting adjustments for improved code alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->