### PR TITLE
Add: any-link selector

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ import Details from "./views/html-tags/Details";
 import Definition from "./views/html-tags/Definition";
 import Progress from "./views/html-tags/Progress";
 import Active from './views/css-styles/Active';
+import AnyLink from './views/css-styles/AnyLink';
 import ImageMap from "./views/responsive-design/ImageMap";
 
 function NotFound() {
@@ -81,6 +82,7 @@ function App() {
           </Route>
           <Route path="/css-styles" element={<CssStylesIndex />}>
             <Route path="/css-styles/active" element={<Active />} />
+            <Route path="/css-styles/any-link" element={<AnyLink />} />
           </Route>
           <Route path="/js-scripts" element={<JsScriptsIndex />}>
             <Route

--- a/src/views/css-styles/AnyLink.jsx
+++ b/src/views/css-styles/AnyLink.jsx
@@ -1,0 +1,30 @@
+import { Container, Card } from "../../components";
+import "./anylink.css"
+
+function AnyLink() {
+  return (
+    <div id="anylink">
+      <Container title=":any-link selector">
+        <Card>
+          <p className="flex flex-col gap-2">
+            <span>
+            {":any-link is a CSS pseudo-class that represents any link that is unvisited or visited."}
+            </span>
+            <span>
+              {"styles for active to be applied in the order LVHA (link, visited, hover, active)"}
+            </span>
+          </p>
+        </Card>
+        <Card>
+          <h2>anchor</h2>
+          <div className="flex gap-2">
+          <a href="#" className="underline text-blue-400">with href</a>
+          <a role="button" className="underline text-blue-400">with role</a>
+          </div>
+        </Card>
+      </Container>
+    </div>
+  )
+}
+
+export default AnyLink;

--- a/src/views/css-styles/Index.jsx
+++ b/src/views/css-styles/Index.jsx
@@ -6,18 +6,19 @@ function Index() {
     document.title = "CSS Styles";
   }, []);
   return (
-    <>
-      <aside className="flex">
+    <div className="flex">
+      <aside className="flex min-w-fit">
         <ul className="p-4 pr-6 w-48">
           <li>
             <Link to="/css-styles/active">:active</Link>
           </li>
+          <li>
+            <Link to="/css-styles/any-link">:any-link</Link>
+          </li>
         </ul>
       </aside>
-      <main className="p-4">
-        <Outlet />
-      </main>
-    </>
+      <Outlet />
+    </div>
   );
 }
 

--- a/src/views/css-styles/anylink.css
+++ b/src/views/css-styles/anylink.css
@@ -1,0 +1,9 @@
+#anylink :any-link {
+  color: red;
+  text-decoration: underline;
+}
+
+#anylink :-webkit-any-link {
+  color: red;
+  text-decoration: underline;
+}


### PR DESCRIPTION
`closes #74 `

just applied the anylink selector to anchor because I think there is no styling for area tag element

https://developer.mozilla.org/ja/docs/Web/CSS/:any-link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new page in the CSS styles section that highlights advanced link styling, now accessible via the app's navigation.

- **Refactor**
  - Improved the layout within the CSS styles area to streamline access to the new view.

- **Style**
  - Applied updated link visuals featuring red color and underlined decoration for a consistent, enhanced appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->