### PR TITLE
Add checked

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,6 +36,7 @@ import Progress from "./views/html-tags/Progress";
 import Active from './views/css-styles/Active';
 import AnyLink from './views/css-styles/AnyLink';
 import Autofill from "./views/css-styles/Autofill";
+import Checked from "./views/css-styles/Checked";
 import ImageMap from "./views/responsive-design/ImageMap";
 
 function NotFound() {
@@ -85,6 +86,7 @@ function App() {
             <Route path="/css-styles/active" element={<Active />} />
             <Route path="/css-styles/any-link" element={<AnyLink />} />
             <Route path="/css-styles/autofill" element={<Autofill />} />
+            <Route path="/css-styles/checked" element={<Checked />} />
           </Route>
           <Route path="/js-scripts" element={<JsScriptsIndex />}>
             <Route

--- a/src/views/css-styles/Checked.jsx
+++ b/src/views/css-styles/Checked.jsx
@@ -1,6 +1,6 @@
 import { Container, Card } from "../../components";
 
-function Autofill() {
+function Checked() {
   return (
     <div>
       <Container title=":checked selector">

--- a/src/views/css-styles/Checked.jsx
+++ b/src/views/css-styles/Checked.jsx
@@ -7,8 +7,8 @@ function Autofill() {
         <Card>
           <p className="flex flex-col gap-2">
             <span>
-            {":autofill is a pseudo-class that represents an element that is being autofilled by the browser."}
-            {"However, the most of modern browsers uses !important for autofill styles so you may find some style properties are not working."}
+            {":checked is a pseudo-class that represents radio and checkbox elements that are in the selected state."}
+            {"It can be used to style elements based on their checked state."}
             </span>
           </p>
         </Card>

--- a/src/views/css-styles/Checked.jsx
+++ b/src/views/css-styles/Checked.jsx
@@ -1,0 +1,46 @@
+import { Container, Card } from "../../components";
+
+function Autofill() {
+  return (
+    <div>
+      <Container title=":checked selector">
+        <Card>
+          <p className="flex flex-col gap-2">
+            <span>
+            {":autofill is a pseudo-class that represents an element that is being autofilled by the browser."}
+            {"However, the most of modern browsers uses !important for autofill styles so you may find some style properties are not working."}
+            </span>
+          </p>
+        </Card>
+        <Card>
+          <h2>Radio button</h2>
+          <div className="flex flex-col gap-2">
+            <div>
+              <input type="radio" name="my-input" id="yes" className="radio-yes peer"/>
+              <label for="yes" className="peer-[.radio-yes]:peer-checked:text-red-500">Yes</label>
+            </div>
+            <div>
+              <input type="radio" name="my-input" id="no" className="radio-no peer"/>
+              <label for="no" className="peer-[.radio-no]:peer-checked:text-red-500">No</label>
+            </div>
+          </div>
+        </Card>
+        <Card>
+          <h2>Checkbox</h2>
+          <div className="flex flex-col gap-2">
+            <div>
+              <input type="checkbox" id="check" className="checkbox-1 peer"/>
+              <label for="check" className="peer-[.checkbox-1]:peer-checked:text-red-500">Check 1</label>
+            </div>
+            <div>
+              <input type="checkbox" id="check2" className="checkbox-2 peer"/>
+              <label for="check2" className="peer-[.checkbox-2]:peer-checked:text-red-500">Check 2</label>
+            </div>
+          </div>
+        </Card>
+      </Container>
+    </div>
+  )
+}
+
+export default Autofill;

--- a/src/views/css-styles/Checked.jsx
+++ b/src/views/css-styles/Checked.jsx
@@ -43,4 +43,4 @@ function Checked() {
   )
 }
 
-export default Autofill;
+export default Checked;

--- a/src/views/css-styles/Checked.jsx
+++ b/src/views/css-styles/Checked.jsx
@@ -17,11 +17,11 @@ function Autofill() {
           <div className="flex flex-col gap-2">
             <div>
               <input type="radio" name="my-input" id="yes" className="radio-yes peer"/>
-              <label for="yes" className="peer-[.radio-yes]:peer-checked:text-red-500">Yes</label>
+              <label htmlFor="yes" className="peer-[.radio-yes]:peer-checked:text-red-500">Yes</label>
             </div>
             <div>
               <input type="radio" name="my-input" id="no" className="radio-no peer"/>
-              <label for="no" className="peer-[.radio-no]:peer-checked:text-red-500">No</label>
+              <label htmlFor="no" className="peer-[.radio-no]:peer-checked:text-red-500">No</label>
             </div>
           </div>
         </Card>
@@ -30,11 +30,11 @@ function Autofill() {
           <div className="flex flex-col gap-2">
             <div>
               <input type="checkbox" id="check" className="checkbox-1 peer"/>
-              <label for="check" className="peer-[.checkbox-1]:peer-checked:text-red-500">Check 1</label>
+              <label htmlFor="check" className="peer-[.checkbox-1]:peer-checked:text-red-500">Check 1</label>
             </div>
             <div>
               <input type="checkbox" id="check2" className="checkbox-2 peer"/>
-              <label for="check2" className="peer-[.checkbox-2]:peer-checked:text-red-500">Check 2</label>
+              <label htmlFor="check2" className="peer-[.checkbox-2]:peer-checked:text-red-500">Check 2</label>
             </div>
           </div>
         </Card>

--- a/src/views/css-styles/Index.jsx
+++ b/src/views/css-styles/Index.jsx
@@ -18,6 +18,9 @@ function Index() {
           <li>
             <Link to="/css-styles/autofill">:autofill</Link>
           </li>
+          <li>
+            <Link to="/css-styles/checked">:checked</Link>
+          </li>
         </ul>
       </aside>
       <Outlet />


### PR DESCRIPTION
`closes #78 `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new route that allows users to explore an enhanced CSS styling demonstration at `/css-styles/checked`.
	- Added a dedicated view showcasing dynamic styling for radio buttons and checkboxes within the new `Autofill` component.
	- Updated the sidebar navigation with a new link to easily access the style demonstration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->