### PR TITLE
Add default selector

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ import Active from './views/css-styles/Active';
 import AnyLink from './views/css-styles/AnyLink';
 import Autofill from "./views/css-styles/Autofill";
 import Checked from "./views/css-styles/Checked";
+import Default from "./views/css-styles/Default";
 import ImageMap from "./views/responsive-design/ImageMap";
 
 function NotFound() {
@@ -87,6 +88,7 @@ function App() {
             <Route path="/css-styles/any-link" element={<AnyLink />} />
             <Route path="/css-styles/autofill" element={<Autofill />} />
             <Route path="/css-styles/checked" element={<Checked />} />
+            <Route path="/css-styles/default" element={<Default />} />
           </Route>
           <Route path="/js-scripts" element={<JsScriptsIndex />}>
             <Route

--- a/src/views/css-styles/Default.jsx
+++ b/src/views/css-styles/Default.jsx
@@ -1,5 +1,4 @@
 import { Container, Card } from "../../components";
-import "./default.css"
 
 function Default() {
   return (
@@ -18,14 +17,14 @@ function Default() {
           <h2>:default check box</h2>
           <form onSubmit={(e) => e.preventDefault()}>
               <label>
-                <input type="checkbox" name="my-check" class="peer" checked/>
-                <span class="h-4 w-4 bg-gray-200 peer-default:bg-blue-200 peer-checked:text-red-500">
+                <input type="checkbox" name="my-check" className="peer" checked/>
+                <span className="h-4 w-4 bg-gray-200 peer-default:bg-blue-200 peer-checked:text-red-500">
                   choice 1
                 </span>
               </label>
               <label>
-                <input type="checkbox" name="my-check" class="peer"/>
-                <span class="h-4 w-4 bg-gray-200  peer-checked:text-red-500">
+                <input type="checkbox" name="my-check" className="peer"/>
+                <span className="h-4 w-4 bg-gray-200  peer-checked:text-red-500">
                   choice 2
                 </span>
               </label>
@@ -35,14 +34,14 @@ function Default() {
           <h2>:default radio button</h2>
           <form onSubmit={(e) => e.preventDefault()}>
               <label>
-                <input type="radio" name="my-input" class="peer" checked/>
-                <span class="h-4 w-4 bg-gray-200 peer-default:bg-blue-200 peer-checked:text-red-500">
+                <input type="radio" name="my-input" className="peer" checked/>
+                <span className="h-4 w-4 bg-gray-200 peer-default:bg-blue-200 peer-checked:text-red-500">
                   Yes
                 </span>
               </label>
               <label>
-                <input type="radio" name="my-input" class="peer"/>
-                <span class="h-4 w-4 bg-gray-200 peer-default:text-blue-500 peer-checked:text-red-500">
+                <input type="radio" name="my-input" className="peer"/>
+                <span className="h-4 w-4 bg-gray-200 peer-default:text-blue-500 peer-checked:text-red-500">
                   No
                 </span>
               </label>
@@ -51,7 +50,7 @@ function Default() {
         <Card>
           <h2>:default button</h2>
           <form onSubmit={(e) => e.preventDefault()}>
-          <button type="submit" value="button" class="p-2 border-none rounded bg-gray-200 default:bg-blue-200 default:text-red-500">
+          <button type="submit" value="button" className="p-2 border-none rounded bg-gray-200 default:bg-blue-200 default:text-red-500">
             submit
           </button>
           </form>

--- a/src/views/css-styles/Default.jsx
+++ b/src/views/css-styles/Default.jsx
@@ -1,0 +1,64 @@
+import { Container, Card } from "../../components";
+import "./default.css"
+
+function Default() {
+  return (
+    <div>
+      <Container title=":default selector">
+        <Card>
+          <p className="flex flex-col gap-2">
+            <span>
+            {":default is a pseudo-class that represents an default element in a group of elements in the same context."}
+            {"However, the most of modern browsers uses !important for Default styles so you may find some style properties are not working."}
+            {"In this demo the background color of the default element is blue and the selected text color is red."}
+            </span>
+          </p>
+        </Card>
+        <Card>
+          <h2>:default check box</h2>
+          <form onSubmit={(e) => e.preventDefault()}>
+              <label>
+                <input type="checkbox" name="my-check" class="peer" checked/>
+                <span class="h-4 w-4 bg-gray-200 peer-default:bg-blue-200 peer-checked:text-red-500">
+                  choice 1
+                </span>
+              </label>
+              <label>
+                <input type="checkbox" name="my-check" class="peer"/>
+                <span class="h-4 w-4 bg-gray-200  peer-checked:text-red-500">
+                  choice 2
+                </span>
+              </label>
+          </form>  
+        </Card>
+        <Card>
+          <h2>:default radio button</h2>
+          <form onSubmit={(e) => e.preventDefault()}>
+              <label>
+                <input type="radio" name="my-input" class="peer" checked/>
+                <span class="h-4 w-4 bg-gray-200 peer-default:bg-blue-200 peer-checked:text-red-500">
+                  Yes
+                </span>
+              </label>
+              <label>
+                <input type="radio" name="my-input" class="peer"/>
+                <span class="h-4 w-4 bg-gray-200 peer-default:text-blue-500 peer-checked:text-red-500">
+                  No
+                </span>
+              </label>
+          </form>
+        </Card>
+        <Card>
+          <h2>:default button</h2>
+          <form onSubmit={(e) => e.preventDefault()}>
+          <button type="submit" value="button" class="p-2 border-none rounded bg-gray-200 default:bg-blue-200 default:text-red-500">
+            submit
+          </button>
+          </form>
+        </Card>
+      </Container>
+    </div>
+  )
+}
+
+export default Default;

--- a/src/views/css-styles/Index.jsx
+++ b/src/views/css-styles/Index.jsx
@@ -21,6 +21,9 @@ function Index() {
           <li>
             <Link to="/css-styles/checked">:checked</Link>
           </li>
+          <li>
+            <Link to="/css-styles/default">:default</Link>
+          </li>
         </ul>
       </aside>
       <Outlet />


### PR DESCRIPTION
`closes #80 `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new page that showcases interactive demonstrations of default CSS styling on form elements.
  - Expanded the navigation menu with a link that directs users to this dedicated demonstration page.
  - Enabled a clearer user experience by adding a new route for accessing modern default pseudo-class styling in various form components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->