### PR TITLE
add disable selector page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,6 +47,7 @@ import Autofill from "./views/css-styles/Autofill";
 import Checked from "./views/css-styles/Checked";
 import Default from "./views/css-styles/Default";
 import Direction from "./views/css-styles/Direction";
+import Disabled from "./views/css-styles/Disabled";
 import ImageMap from "./views/responsive-design/ImageMap";
 
 function NotFound() {
@@ -107,6 +108,7 @@ function App() {
             <Route path="/css-styles/checked" element={<Checked />} />
             <Route path="/css-styles/default" element={<Default />} />
             <Route path="/css-styles/dir" element={<Direction />}/>
+            <Route path="/css-styles/disabled" element={<Disabled />} />
           </Route>
           <Route path="/js-scripts" element={<JsScriptsIndex />}>
             <Route

--- a/src/views/css-styles/Disabled.jsx
+++ b/src/views/css-styles/Disabled.jsx
@@ -18,7 +18,6 @@ export default function DisabledPage() {
         <p className="flex flex-col gap-2">
           <span>
           {`:disabled is a CSS pseudo-class that is used to style elements that are disabled
-          The :disabled pseudo-class is used to style elements that are disabled.
           The pseudo-class can be used
           to change the appearance of
           disabled elements, such as changing the color or background color of the element.`}

--- a/src/views/css-styles/Disabled.jsx
+++ b/src/views/css-styles/Disabled.jsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import { Container, Card } from "../../components";
+
+export default function DisabledPage() {
+  const [isInputDisabled, setIsInputDisabled] = useState(false);
+  const [isButtonDisabled, setIsButtonDisabled] = useState(false);
+  const [isSelectDisabled, setIsSelectDisabled] = useState(false);
+  const [isTextareaDisabled, setIsTextareaDisabled] = useState(false);
+  const [isCheckboxDisabled, setIsCheckboxDisabled] = useState(false);
+  const [isRadioDisabled, setIsRadioDisabled] = useState(false);
+  const [isSubmitDisabled, setIsSubmitDisabled] = useState(false);
+  const [isFieldsetDisabled, setIsFieldsetDisabled] = useState(false);
+  const [isOptgroupDisabled, setIsOptgroupDisabled] = useState(false);
+  const [isOptionDisabled, setIsOptionDisabled] = useState(false);
+  return (
+    <Container title=":disabled">
+      <Card>
+        <p className="flex flex-col gap-2">
+          <span>
+          {`:disabled is a CSS pseudo-class that is used to style elements that are disabled
+          The :disabled pseudo-class is used to style elements that are disabled.
+          The pseudo-class can be used
+          to change the appearance of
+          disabled elements, such as changing the color or background color of the element.`}
+          </span>
+        </p>
+      </Card>
+      <Card>
+        <h2>Disable Controller</h2>
+        <div className="grid grid-cols-2 gap-2">
+          <label>
+            <input
+              type="checkbox"
+              checked={isInputDisabled}
+              onChange={() => setIsInputDisabled(!isInputDisabled)}
+            />
+            Input
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={isButtonDisabled}
+              onChange={() => setIsButtonDisabled(!isButtonDisabled)}
+            />
+            Button
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={isSelectDisabled}
+              onChange={() => setIsSelectDisabled(!isSelectDisabled)}
+            />
+            Select
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={isTextareaDisabled}
+              onChange={() => setIsTextareaDisabled(!isTextareaDisabled)}
+            />
+            Textarea
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={isCheckboxDisabled}
+              onChange={() => setIsCheckboxDisabled(!isCheckboxDisabled)}
+            />
+            Checkbox
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={isRadioDisabled}
+              onChange={() => setIsRadioDisabled(!isRadioDisabled)}
+            />
+            Radio
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={isSubmitDisabled}
+              onChange={() => setIsSubmitDisabled(!isSubmitDisabled)}
+            />
+            Submit
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={isFieldsetDisabled}
+              onChange={() => setIsFieldsetDisabled(!isFieldsetDisabled)}
+            />
+            Fieldset
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={isOptgroupDisabled}
+              onChange={() => setIsOptgroupDisabled(!isOptgroupDisabled)}
+            />
+            Optgroup
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={isOptionDisabled}
+              onChange={() => setIsOptionDisabled(!isOptionDisabled)}
+            />
+            Option
+          </label>
+        </div>
+        <form onSubmit={(e) => e.preventDefault()}>
+          <fieldset disabled={isFieldsetDisabled} className="flex flex-col gap-2 w-fit rounded p-4">
+            <legend className="font-bold">Form</legend>
+            <input className="p-2 text-black disabled:text-gray-400" placeholder="text" type="text" disabled={isInputDisabled} />
+            <button className="p-2 rounded-md bg-blue-600 text-white disabled:bg-gray-300 disabled:text-gray-700" type="button" disabled={isButtonDisabled}>
+              Button
+            </button>
+            <select className="rounded p-2" disabled={isSelectDisabled}>
+              <option>Option 1</option>
+              <option>Option 2</option>
+              <option>Option 3</option>
+            </select>
+            <textarea className="p-2 rounded" disabled={isTextareaDisabled} />
+            <label>
+              <input type="checkbox" disabled={isCheckboxDisabled} />
+              Checkbox
+            </label>
+            <label>
+              <input type="radio" disabled={isRadioDisabled} />
+              Radio
+            </label>
+            <input type="submit" value="Submit" className="rounded p-2 border-none bg-green-600 text-white disabled:bg-gray-300 disabled:text-gray-700"  disabled={isSubmitDisabled} />
+            <select>
+              <option disabled={isOptionDisabled}>Option 1</option>
+              <optgroup label="Group" disabled={isOptgroupDisabled}>
+                <option>Option 1</option>
+                <option>Option 2</option>
+                <option>Option 3</option>
+              </optgroup>
+            </select>
+          </fieldset>
+        </form>
+      </Card>
+    </Container>
+  )
+}

--- a/src/views/css-styles/Index.jsx
+++ b/src/views/css-styles/Index.jsx
@@ -25,7 +25,10 @@ function Index() {
             <Link to="/css-styles/default">:default</Link>
           </li>
           <li>
-            <Link to="/css-styles/dir">:{"dir()"}</Link>
+            <Link to="/css-styles/dir">:{":dir()"}</Link>
+          </li>
+          <li>
+            <Link to="/css-styles/disabled">:disabled</Link>
           </li>
         </ul>
       </aside>


### PR DESCRIPTION
`closes #105 `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive demonstration page allowing users to toggle disabled states for various form elements.
  - Added a new route accessible via the `/css-styles/disabled` path.
  - Updated the navigation menu to include a link to the new demonstration page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->